### PR TITLE
Handle servers that don't support range parameter

### DIFF
--- a/html/js/nexus.js
+++ b/html/js/nexus.js
@@ -281,7 +281,15 @@ Mesh.prototype = {
 		r.open('GET', this.url(), true);
 		r.responseType = type;
 		r.setRequestHeader("Range", "bytes=" + start + "-" + (end -1));
-		r.onload = load;
+		r.onload = function(){
+			switch (this.status){
+				case 206:
+                			load.bind(this)();
+                			break;
+				case 200:
+					console.log("200 response; server does not support byte range requests.")
+			}
+        	};
 		r.onerror = error;
 		r.onabort = abort;
 		r.send();


### PR DESCRIPTION
Nexus XHRs always request a byte range. Servers like python's SimpleHTTPServer and WebStorm's built in dev server do not support byte range requests -- they return a 200 status instead of 206, and send the whole file. In these cases, Nexus gets into an endless loop and hangs the browser. Easy fix is not to proceed if the status comes back 200. Fixes #2 .