### PR TITLE
Origin can be moved. Need for georeferenced models precision issues.

### DIFF
--- a/src/nxsbuild/kdtree.cpp
+++ b/src/nxsbuild/kdtree.cpp
@@ -300,7 +300,7 @@ void KDTreeSoup::splitNode(KDCell &node, KDCell &child0, KDCell &child1) {
 	}
 	source.resize(n0);
 	if(source.size() == 0 || dest.size() == 0)
-		throw "Degenerate point cloud";
+		cerr <<  "Degenerate point cloud" << cells.size() << endl;
 	drop(child0.block);
 	drop(child1.block);
 }

--- a/src/nxsbuild/kdtree.cpp
+++ b/src/nxsbuild/kdtree.cpp
@@ -56,7 +56,6 @@ void KDTree::load(Stream *stream) {
 
 	float precision = boxFloatPrecision(node.box);
 	if(precision < 12) {
-			cout << node.box.min[0] << endl;
 			throw QString("quantiziation is too severe!\n"
 			              "The bounding box is far from the origin (with respect to its size),\n"
 			              "the model MIGHT be quantized.\n"

--- a/src/nxsbuild/main.cpp
+++ b/src/nxsbuild/main.cpp
@@ -189,7 +189,21 @@ int main(int argc, char *argv[]) {
 			stream->origin = box.Center();
 		} else
 			stream->origin = origin;
+		
+		vcg::Point3d &o = stream->origin;
+		if(o[0] != 0.0 || o[1] != 0.0 || o[2] != 0.0) {
+			int lastPoint = output.lastIndexOf(".");
+			QString ref = output.left(lastPoint) + ".ref";
+			QFile file(ref);
+			if(!file.open(QFile::ReadWrite)) {
+				cerr << "Could not save reference file: " << qPrintable(ref) << endl;
+				return -1;
+			}
+			QTextStream stream(&file);
+			stream << "{ origin: [" << o[0] << ", " << o[1] << " " << o[2] << "] }\n";
+		}
 		stream->load(inputs, mtl);
+
 
 		bool has_colors = stream->hasColors();
 		bool has_normals = stream->hasNormals();

--- a/src/nxsbuild/meshloader.h
+++ b/src/nxsbuild/meshloader.h
@@ -36,9 +36,13 @@ public:
 	virtual bool hasColors() { return has_colors; } //call this
 	virtual bool hasNormals() { return has_normals; } //call this
 	virtual bool hasTextures() { return has_textures; }
+	
+	vcg::Point3d origin = vcg::Point3d(0, 0, 0);
+	vcg::Box3d box;
+	
 	std::vector<QString> texture_filenames;
 	int texOffset; //when returning triangles add texOffset to refer to the correct texture in stream.
-	vcg::Point3d origin;
+
 	
 protected:
 	bool has_colors;

--- a/src/nxsbuild/meshstream.h
+++ b/src/nxsbuild/meshstream.h
@@ -42,6 +42,7 @@ public:
 	Stream();
 	virtual ~Stream() {}
 	void setVertexQuantization(double q);
+	vcg::Box3d getBox(QStringList paths);
 	void load(QStringList paths, QString material);
 
 	//return a block of triangles. The buffer is valid until next call to getTriangles. Return null when finished
@@ -60,6 +61,8 @@ protected:
 	quint64 current_triangle;   //used both for loading and streaming
 	quint64 current_block;
 
+	MeshLoader *getLoader(QString file, QString material);
+		
 	virtual void flush() = 0;
 	virtual void loadMesh(MeshLoader *loader) = 0;
 	virtual void clearVirtual() = 0; //clear the virtualtrianglesoup or virtualtrianglebin

--- a/src/nxsbuild/plyloader.cpp
+++ b/src/nxsbuild/plyloader.cpp
@@ -211,8 +211,6 @@ void PlyLoader::cacheVertices() {
 	vertices.setElementsPerBlock(1<<20);
 	vertices.resize(n_vertices);
 
-	bool translate = (origin[0] != 0.0 || origin[1] != 0.0 || origin[2] != 0.0);
-	
 	PlyVertex vertex;
 	//caching vertices on temporary file
 	for(quint64 i = 0; i < n_vertices; i++) {
@@ -320,13 +318,15 @@ quint32 PlyLoader::getVertices(quint32 size, Splat *splats) {
 		current_vertex++;
 
 		if(double_coords) {
-			v.v[0] = vertex.dv[0] - origin[0];
-			v.v[1] = vertex.dv[1] - origin[1];
-			v.v[2] = vertex.dv[2] - origin[2];
+			box.Add(vcg::Point3d(vertex.dv) - origin);
+			v.v[0] = (float)(vertex.dv[0] - origin[0]);
+			v.v[1] = (float)(vertex.dv[1] - origin[1]);
+			v.v[2] = (float)(vertex.dv[2] - origin[2]);
 		} else {
-			v.v[0] = vertex.v[0] - origin[0];
-			v.v[1] = vertex.v[1] - origin[1];
-			v.v[2] = vertex.v[2] - origin[2];
+			box.Add(vcg::Point3d(vertex.v[0], vertex.v[1], vertex.v[2]) - origin);
+			v.v[0] = vertex.v[0] - (float)origin[0];
+			v.v[1] = vertex.v[1] - (float)origin[1];
+			v.v[2] = vertex.v[2] - (float)origin[2];
 		}
 		if(has_colors) {
 			v.c[0] = vertex.c[0];

--- a/src/nxsbuild/plyloader.cpp
+++ b/src/nxsbuild/plyloader.cpp
@@ -31,26 +31,35 @@ struct PlyFace {
 	quint32 texNumber;
 	unsigned char n;
 };
+
+struct PlyVertex {
+	double dv[3];
+	float v[3];
+	float t[2]; //texture
+	float n[3];
+	unsigned char c[4]; //colors
+};
+
 //TODO add uv?
 PropDescriptor plyprop1[13]= {
-	{"vertex", "x",     T_FLOAT, T_FLOAT, offsetof(Vertex,v[0]),0,0,0,0,0,0},
-	{"vertex", "y",     T_FLOAT, T_FLOAT, offsetof(Vertex,v[1]),0,0,0,0,0,0},
-	{"vertex", "z",     T_FLOAT, T_FLOAT, offsetof(Vertex,v[2]),0,0,0,0,0,0},
-	{"vertex", "red"  , T_UCHAR, T_UCHAR, offsetof(Vertex,c[0]),0,0,0,0,0,0},
-	{"vertex", "green", T_UCHAR, T_UCHAR, offsetof(Vertex,c[1]),0,0,0,0,0,0},
-	{"vertex", "blue" , T_UCHAR, T_UCHAR, offsetof(Vertex,c[2]),0,0,0,0,0,0},
-	{"vertex", "alpha", T_UCHAR, T_UCHAR, offsetof(Vertex,c[3]),0,0,0,0,0,0},
-	{"vertex", "nx",    T_FLOAT, T_FLOAT, offsetof(Splat, n[0]),0,0,0,0,0,0},
-	{"vertex", "ny",    T_FLOAT, T_FLOAT, offsetof(Splat, n[1]),0,0,0,0,0,0},
-	{"vertex", "nz",    T_FLOAT, T_FLOAT, offsetof(Splat, n[2]),0,0,0,0,0,0},
-	{"vertex", "diffuse_red",   T_UCHAR, T_UCHAR, offsetof(Vertex,c[0]),0,0,0,0,0,0},
-	{"vertex", "diffuse_green", T_UCHAR, T_UCHAR, offsetof(Vertex,c[1]),0,0,0,0,0,0},
-	{"vertex", "diffuse_blue" , T_UCHAR, T_UCHAR, offsetof(Vertex,c[2]),0,0,0,0,0,0},
+	{"vertex", "x",     T_FLOAT, T_FLOAT, offsetof(PlyVertex,v[0]),0,0,0,0,0,0},
+	{"vertex", "y",     T_FLOAT, T_FLOAT, offsetof(PlyVertex,v[1]),0,0,0,0,0,0},
+	{"vertex", "z",     T_FLOAT, T_FLOAT, offsetof(PlyVertex,v[2]),0,0,0,0,0,0},
+	{"vertex", "red"  , T_UCHAR, T_UCHAR, offsetof(PlyVertex,c[0]),0,0,0,0,0,0},
+	{"vertex", "green", T_UCHAR, T_UCHAR, offsetof(PlyVertex,c[1]),0,0,0,0,0,0},
+	{"vertex", "blue" , T_UCHAR, T_UCHAR, offsetof(PlyVertex,c[2]),0,0,0,0,0,0},
+	{"vertex", "alpha", T_UCHAR, T_UCHAR, offsetof(PlyVertex,c[3]),0,0,0,0,0,0},
+	{"vertex", "nx",    T_FLOAT, T_FLOAT, offsetof(PlyVertex, n[0]),0,0,0,0,0,0},
+	{"vertex", "ny",    T_FLOAT, T_FLOAT, offsetof(PlyVertex, n[1]),0,0,0,0,0,0},
+	{"vertex", "nz",    T_FLOAT, T_FLOAT, offsetof(PlyVertex, n[2]),0,0,0,0,0,0},
+	{"vertex", "diffuse_red",   T_UCHAR, T_UCHAR, offsetof(PlyVertex,c[0]),0,0,0,0,0,0},
+	{"vertex", "diffuse_green", T_UCHAR, T_UCHAR, offsetof(PlyVertex,c[1]),0,0,0,0,0,0},
+	{"vertex", "diffuse_blue" , T_UCHAR, T_UCHAR, offsetof(PlyVertex,c[2]),0,0,0,0,0,0},
 };
 PropDescriptor doublecoords[3] = {
-	{"vertex", "x",     T_DOUBLE, T_FLOAT, offsetof(Vertex,v[0]),0,0,0,0,0,0},
-	{"vertex", "y",     T_DOUBLE, T_FLOAT, offsetof(Vertex,v[1]),0,0,0,0,0,0},
-	{"vertex", "z",     T_DOUBLE, T_FLOAT, offsetof(Vertex,v[2]),0,0,0,0,0,0}
+	{"vertex", "x",     T_DOUBLE, T_DOUBLE, offsetof(PlyVertex,dv[0]),0,0,0,0,0,0},
+	{"vertex", "y",     T_DOUBLE, T_DOUBLE, offsetof(PlyVertex,dv[1]),0,0,0,0,0,0},
+	{"vertex", "z",     T_DOUBLE, T_DOUBLE, offsetof(PlyVertex,dv[2]),0,0,0,0,0,0}
 };
 
 PropDescriptor vindex[1]=	{
@@ -149,9 +158,11 @@ void PlyLoader::init() {
 	if(pf.AddToRead(plyprop1[0])==-1 ||
 			pf.AddToRead(plyprop1[1])==-1 ||
 			pf.AddToRead(plyprop1[2])==-1) {
+		
 		if(pf.AddToRead(doublecoords[0])==-1 ||
 				pf.AddToRead(doublecoords[1])==-1 ||
 				pf.AddToRead(doublecoords[2])==-1) {
+			double_coords = true;
 			throw QString("ply file is missing xyz coords");
 		}
 	}
@@ -200,10 +211,33 @@ void PlyLoader::cacheVertices() {
 	vertices.setElementsPerBlock(1<<20);
 	vertices.resize(n_vertices);
 
+	bool translate = (origin[0] != 0.0 || origin[1] != 0.0 || origin[2] != 0.0);
+	
+	PlyVertex vertex;
 	//caching vertices on temporary file
 	for(quint64 i = 0; i < n_vertices; i++) {
 		Vertex &v = vertices[i];
-		pf.Read((void *)&v);
+		pf.Read((void *)&vertex);
+		if(double_coords) {
+			v.v[0] = vertex.dv[0] - origin[0];
+			v.v[1] = vertex.dv[1] - origin[1];
+			v.v[2] = vertex.dv[2] - origin[2];
+		} else {
+			v.v[0] = vertex.v[0] - origin[0];
+			v.v[1] = vertex.v[1] - origin[1];
+			v.v[2] = vertex.v[2] - origin[2];
+		}
+		if(has_colors) {
+			v.c[0] = vertex.c[0];
+			v.c[1] = vertex.c[1];
+			v.c[2] = vertex.c[2];
+			v.c[3] = vertex.c[3];
+		}
+		if(has_textures) {
+			v.t[0] = vertex.t[0];
+			v.t[1] = vertex.t[1];
+		}
+		
 		if(quantization) {
 			quantize(v.v[0]);
 			quantize(v.v[1]);
@@ -269,23 +303,52 @@ quint32 PlyLoader::getTriangles(quint32 size, Triangle *buffer) {
 	return count;
 }
 
-quint32 PlyLoader::getVertices(quint32 size, Splat *vertex) {
+quint32 PlyLoader::getVertices(quint32 size, Splat *splats) {
 	if(current_triangle > n_triangles) return 0;
 
+	PlyVertex vertex;
+	
 	Splat v;
 	v.node = 0;
 	v.c[3] = 255;
 	quint32 count = 0;
 	for(quint32 i = 0; i < size && current_vertex < n_vertices; i++) {
-		pf.Read((void *)&v);
+
+		pf.Read((void *)&vertex);
+
+		Splat &v = splats[count++];
+		current_vertex++;
+
+		if(double_coords) {
+			v.v[0] = vertex.dv[0] - origin[0];
+			v.v[1] = vertex.dv[1] - origin[1];
+			v.v[2] = vertex.dv[2] - origin[2];
+		} else {
+			v.v[0] = vertex.v[0] - origin[0];
+			v.v[1] = vertex.v[1] - origin[1];
+			v.v[2] = vertex.v[2] - origin[2];
+		}
+		if(has_colors) {
+			v.c[0] = vertex.c[0];
+			v.c[1] = vertex.c[1];
+			v.c[2] = vertex.c[2];
+			v.c[3] = vertex.c[3];
+		}
+		if(has_textures) {
+			v.t[0] = vertex.t[0];
+			v.t[1] = vertex.t[1];
+		}
+		if(has_normals) {
+			v.n[0] = vertex.n[0];
+			v.n[1] = vertex.n[1];
+			v.n[2] = vertex.n[2];
+		}
+
 		if(quantization) {
 			quantize(v.v[0]);
 			quantize(v.v[1]);
 			quantize(v.v[2]);
 		}
-		vertex[count] = v;
-		current_vertex++;
-		count++;
 	}
 	return count;
 }

--- a/src/nxsbuild/plyloader.h
+++ b/src/nxsbuild/plyloader.h
@@ -38,6 +38,7 @@ public:
 	quint32 nTriangles() { return n_triangles; }
 private:
 	vcg::ply::PlyFile pf;
+	bool double_coords = false;
 	qint64 vertices_element;
 	qint64 faces_element;
 

--- a/src/nxsbuild/stlloader.cpp
+++ b/src/nxsbuild/stlloader.cpp
@@ -36,12 +36,16 @@ facet normal nx ny nz
 endfacet */
 
 quint32 STLLoader::getTrianglesAscii(quint32 size, Triangle *buffer) {
-	int readed = 0;
+	quint32 readed = 0;
 	char line[1024];
 	char dummy[1024];
+	
+	bool translate = (origin[0] != 0.0 || origin[1] != 0.0 || origin[2] != 0.0);
+	
+	
 	for(int i = 0; i < size; i++) {
 
-		int ok = file.readLine(line, 1023); //facet
+		qint64 ok = file.readLine(line, 1023); //facet
 		if(ok <= 0) return readed;
 
 		ok = file.readLine(line, 1023); //normal
@@ -56,9 +60,19 @@ quint32 STLLoader::getTrianglesAscii(quint32 size, Triangle *buffer) {
 			ok = file.readLine(line, 1023); //normal
 			if(ok <= 0) return readed;
 
-			int n = sscanf(line, "%s %f %f %f", dummy, v, v+1, v+2);
-			if(n != 4)
-				throw QString("Invalid STL file");
+			if(translate) {
+				double d[3];
+				int n = sscanf(line, "%s %lf %lf %lf", dummy, &d[0], &d[1], &d[2]);
+				if(n != 4)
+					throw QString("Invalid STL file");
+				v[0] = (float)(d[0] - origin[0]);
+				v[1] = (float)(d[1] - origin[1]);
+				v[2] = (float)(d[2] - origin[1]);
+			} else {
+				int n = sscanf(line, "%s %f %f %f", dummy, v, v+1, v+2);
+				if(n != 4)
+					throw QString("Invalid STL file");
+			}
 		}
 		current_triangle++;
 		readed++;
@@ -89,7 +103,7 @@ quint32 STLLoader::getTrianglesBinary(quint32 size, Triangle *buffer) {
 		Triangle &tri = buffer[i];
 		for(int t = 0; t < 3; t++)
 			for(int k = 0; k < 3; k++)
-				tri.vertices[t].v[k] = pos[t*3 + k];
+				tri.vertices[t].v[k] = pos[t*3 + k] - origin[k];
 		tri.node = 0;
 		current_triangle++;
 		start += 50;

--- a/src/nxsbuild/stlloader.cpp
+++ b/src/nxsbuild/stlloader.cpp
@@ -40,9 +40,6 @@ quint32 STLLoader::getTrianglesAscii(quint32 size, Triangle *buffer) {
 	char line[1024];
 	char dummy[1024];
 	
-	bool translate = (origin[0] != 0.0 || origin[1] != 0.0 || origin[2] != 0.0);
-	
-	
 	for(int i = 0; i < size; i++) {
 
 		qint64 ok = file.readLine(line, 1023); //facet
@@ -60,19 +57,16 @@ quint32 STLLoader::getTrianglesAscii(quint32 size, Triangle *buffer) {
 			ok = file.readLine(line, 1023); //normal
 			if(ok <= 0) return readed;
 
-			if(translate) {
-				double d[3];
-				int n = sscanf(line, "%s %lf %lf %lf", dummy, &d[0], &d[1], &d[2]);
-				if(n != 4)
-					throw QString("Invalid STL file");
-				v[0] = (float)(d[0] - origin[0]);
-				v[1] = (float)(d[1] - origin[1]);
-				v[2] = (float)(d[2] - origin[1]);
-			} else {
-				int n = sscanf(line, "%s %f %f %f", dummy, v, v+1, v+2);
-				if(n != 4)
-					throw QString("Invalid STL file");
-			}
+			vcg::Point3d d;
+			int n = sscanf(line, "%s %lf %lf %lf", dummy, &d[0], &d[1], &d[2]);
+			if(n != 4)
+				throw QString("Invalid STL file");
+			d -= origin;
+			box.Add(d);
+					
+			v[0] = (float)(d[0]);
+			v[1] = (float)(d[1]);
+			v[2] = (float)(d[2]);
 		}
 		current_triangle++;
 		readed++;


### PR DESCRIPTION
The --origin x:y:z  option allows to specifty the origin of the model when converting to nxs.
This is needed for georeferenced models saved in double precision since .nxs uses 32bit floating points numbers and would lose precision.
 The --center switch places the origin in the center of the bounding box.

The translations parameters are stored in an additional file <output>.ref in json format.