### PR TITLE
removed UV bounds check

### DIFF
--- a/src/nxsbuild/nexusbuilder.cpp
+++ b/src/nxsbuild/nexusbuilder.cpp
@@ -294,12 +294,7 @@ QImage NexusBuilder::extractNodeTex(TMesh &mesh, int level, float &error, float 
 		vcg::Box2f &box = boxes[b];
 		box_texture[b] = tex;
 		auto &t = mesh.vert[i].T().P();
-		t[0] = fmod(t[0], 1.0);
-		t[1] = fmod(t[1], 1.0);
-//		if(isnan(t[0]) || isnan(t[1]) || t[0] < 0 || t[1] < 0 || t[0] > 1 || t[1] > 1)
-//				cout << "T: " << t[0] << " " << t[1] << endl;
-		if(t[0] != 0.0f || t[1] != 0.0f)
-			box.Add(t);
+		box.Add(t);
 	}
 	//erase boxes assigned to no texture, and remap vertex_to_box
 	int count = 0;

--- a/src/nxsbuild/plyloader.cpp
+++ b/src/nxsbuild/plyloader.cpp
@@ -273,17 +273,6 @@ quint32 PlyLoader::getTriangles(quint32 size, Triangle *buffer) {
 			vertex.t[0] = face.t[k*2];
 			vertex.t[1] = face.t[k*2+1];
 
-			if (has_textures) {
-				while (vertex.t[0] > 1.0f)
-					vertex.t[0] -= 1.0f;
-				while (vertex.t[1] > 1.0f)
-					vertex.t[1] -= 1.0f;
-				while (vertex.t[0] < 0.0f)
-					vertex.t[0] += 1.0f;
-				while (vertex.t[1] < 0.0f)
-					vertex.t[1] += 1.0f;
-			}
-
 			current.vertices[k] = vertex;
 		}
 		//TODO! detect complicated texture coordinates


### PR DESCRIPTION
say we have a tri with 3 verts that have these uvs:
[0.9, 0.95], [0.95, .9], [1.05, 1.05]
Currently nexus will adjust those UVs to be
[0.9, 0.95], [0.95, .9], [0.05, 0.05]
Which will look like we are dealing with a tri that spans most of the texture, which is incorrect