### PR TITLE
Removing the dependency from QFile, QImage and QTime into NexusData

### DIFF
--- a/src/common/nexus.cpp
+++ b/src/common/nexus.cpp
@@ -71,8 +71,8 @@ bool Nexus::open(const char *_uri) {
 		url = url.substr(7, url.size());
 
 	if(!isStreaming()) {
-		file.setFileName(url.c_str());
-		if(!file.open(QIODevice::ReadWrite))
+		file->setFileName(url.c_str());
+		if(!file->open(NexusFile::ReadWrite))
 			//file = fopen(_uri, "rb+");
 			//if(!file)
 			return false;
@@ -110,6 +110,38 @@ void Nexus::loadIndex(char *buffer) {
 	NexusData::loadIndex(buffer);
 
 	loaded = true;
+}
+void nx::Nexus::loadImageFromData(nx::TextureData& data, int t)
+{
+	Texture& texture = textures[t];
+	data.memory = (char*)file->map(texture.getBeginOffset(), texture.getSize());
+	if (!data.memory) {
+		cerr << "Failed mapping texture data" << endl;
+		exit(0);
+	}
+	QImage img;
+	bool success = img.loadFromData((uchar*)data.memory, texture.getSize());
+	file->unmap((uchar*)data.memory);
+
+	if (!success) {
+		cerr << "Failed loading texture" << endl;
+		exit(0);
+	}
+
+	img = img.convertToFormat(QImage::Format_RGBA8888);
+	data.width = img.width();
+	data.height = img.height();
+
+	int imgsize = data.width * data.height * 4;
+	data.memory = new char[imgsize];
+
+	//flip memory for texture
+	int linesize = img.width() * 4;
+	char* mem = data.memory + linesize * (img.height() - 1);
+	for (int i = 0; i < img.height(); i++) {
+		memcpy(mem, img.scanLine(i), linesize);
+		mem -= linesize;
+	}
 }
 void Nexus::loadIndex() {
 	NexusData::loadIndex();

--- a/src/common/nexus.cpp
+++ b/src/common/nexus.cpp
@@ -56,6 +56,7 @@ Nexus::Nexus(Controller *control): controller(control), loaded(false), http_stre
 
 Nexus::~Nexus() {
 	close();
+	delete file;
 }
 
 bool Nexus::open(const char *_uri) {

--- a/src/common/nexus.cpp
+++ b/src/common/nexus.cpp
@@ -20,6 +20,7 @@ for more details.
 #include "nexus.h"
 #include "controller.h"
 #include "globalgl.h"
+#include "qtnexusfile.h"
 
 #include <QGLWidget>
 
@@ -50,6 +51,7 @@ void _glCheckError(const char *file, int line) {
 
 
 Nexus::Nexus(Controller *control): controller(control), loaded(false), http_stream(false) {
+	file = new QTNexusFile();
 }
 
 Nexus::~Nexus() {

--- a/src/common/nexus.h
+++ b/src/common/nexus.h
@@ -20,6 +20,8 @@ for more details.
 
 #include "nexusdata.h"
 
+#include <QString>
+
 typedef void CURL;
 
 namespace nx {
@@ -46,6 +48,8 @@ public:
 	void initIndex();
 	void loadIndex();
 	void loadIndex(char *buffer);
+
+	void loadImageFromData(nx::TextureData& data, int textureIndex) override;
 
 	bool loaded;
 	bool http_stream;

--- a/src/common/nexusdata.cpp
+++ b/src/common/nexusdata.cpp
@@ -17,8 +17,6 @@ for more details.
 */
 #define _FILE_OFFSET_BITS 64
 
-#include <QTime>
-#include <QImage>
 #include "nexusdata.h"
 
 #include <vcg/space/line3.h>
@@ -42,6 +40,7 @@ uint16_t *NodeData::faces(Signature &sig, uint32_t nvert, char *mem) {
 
 
 NexusData::NexusData(): nodes(0), patches(0), textures(0), nodedata(0), texturedata(0), nroots(0) {
+
 }
 
 NexusData::~NexusData() {
@@ -49,9 +48,9 @@ NexusData::~NexusData() {
 }
 
 bool NexusData::open(const char *_uri) {
-
-	file.setFileName(_uri);
-	if(!file.open(QIODevice::ReadOnly))
+	file = NexusFile::create();
+	file->setFileName(_uri);
+	if(!file->open(NexusFile::Read))
 		//file = fopen(_uri, "rb+");
 		//if(!file)
 		return false;
@@ -66,7 +65,7 @@ void NexusData::close() {
 
 void NexusData::flush() {
 	//flush
-	for(uint i = 0; i < header.n_nodes; i++)
+	for(unsigned int i = 0; i < header.n_nodes; i++)
 		delete nodedata[i].memory;
 
 	delete []nodes;
@@ -78,17 +77,17 @@ void NexusData::flush() {
 
 void NexusData::loadHeader() {
 	//fread(&header, sizeof(Header), 1, file);
-	int readed = file.read((char *)&header, sizeof(Header));
-	if(readed != sizeof(Header))
-		throw QString("could not read header, file too short");
+	int readed = file->read((char *)&header, sizeof(Header));
+	if (readed != sizeof(Header))
+		throw std::string ("could not read header, file too short");
 	if(header.magic != 0x4E787320)
-		throw QString("could not read header, probably not a nexus file");
+		throw std::string("could not read header, probably not a nexus file");
 }
 
 void NexusData::loadHeader(char *buffer) {
 	header = *(Header *)buffer;
 	if(header.magic != 0x4E787320)
-		throw QString("could not read header, probably not a nexus file");
+		throw std::string("could not read header, probably not a nexus file");
 }
 
 void NexusData::countRoots() {
@@ -122,9 +121,9 @@ void NexusData::loadIndex() {
 	//fread(nodes, sizeof(Node), header.n_nodes, file);
 	//fread(patches, sizeof(Patch), header.n_patches, file);
 	//fread(textures, sizeof(Texture), header.n_textures, file);
-	file.read((char *)nodes, sizeof(Node)*header.n_nodes);
-	file.read((char *)patches, sizeof(Patch)*header.n_patches);
-	file.read((char *)textures, sizeof(Texture)*header.n_textures);
+	file->read((char *)nodes, sizeof(Node)*header.n_nodes);
+	file->read((char *)patches, sizeof(Patch)*header.n_patches);
+	file->read((char *)textures, sizeof(Texture)*header.n_textures);
 	countRoots();
 }
 
@@ -153,29 +152,27 @@ uint64_t NexusData::loadRam(uint32_t n) {
 
 	Signature &sign = header.signature;
 	Node &node = nodes[n];
-	quint64 offset = node.getBeginOffset();
+	uint64_t offset = node.getBeginOffset();
 
 	NodeData &d = nodedata[n];
-	quint64 compressed_size = node.getEndOffset() - offset;
+	uint64_t compressed_size = node.getEndOffset() - offset;
 
-	quint64 size = node.nvert*sign.vertex.size() + node.nface*sign.face.size();
+	uint64_t size = node.nvert*sign.vertex.size() + node.nface*sign.face.size();
 
 	if(!sign.isCompressed()) {
 
-		d.memory = (char *)file.map(offset, size);
+		d.memory = (char *)file->map(offset, size);
 
 	} else {
 
 		char *buffer = new char[compressed_size];
-		file.seek(offset);
-		qint64 r = file.read(buffer, compressed_size);
-		assert(r == (qint64)compressed_size);
+		file->seek(offset);
+		int64_t r = file->read(buffer, compressed_size);
+		assert(r == (int64_t)compressed_size);
 
 		d.memory = new char[size];
 
 		int iterations = 1;
-		QTime time;
-		time.start();
 
 		if(sign.flags & Signature::MECO) {
 			meco::MeshDecoder coder(node, d, patches, sign);
@@ -242,15 +239,18 @@ uint64_t NexusData::loadRam(uint32_t n) {
 				continue;
 
 			Texture &texture = textures[t];
-			data.memory = (char *)file.map(texture.getBeginOffset(), texture.getSize());
+			data.memory = (char *)file->map(texture.getBeginOffset(), texture.getSize());
 			if(!data.memory) {
 				cerr << "Failed mapping texture data" << endl;
 				exit(0);
 			}
 
+			loadImageFromData(data, t);
+
+			/*
 			QImage img;
 			bool success = img.loadFromData((uchar *)data.memory, texture.getSize());
-			file.unmap((uchar *)data.memory);
+			file->unmap((uchar *)data.memory);
 
 			if(!success) {
 				cerr << "Failed loading texture" << endl;
@@ -271,6 +271,8 @@ uint64_t NexusData::loadRam(uint32_t n) {
 				memcpy(mem, img.scanLine(i), linesize);
 				mem -= linesize;
 			}
+			*/
+			int imgsize = data.width * data.height * 4;
 			size += imgsize;
 		}
 	}
@@ -286,7 +288,7 @@ uint64_t NexusData::dropRam(uint32_t n, bool write) {
 	assert(data.memory);
 
 	if(!header.signature.isCompressed()) //not compressed.
-		file.unmap((uchar *)data.memory);
+		file->unmap((unsigned char *)data.memory);
 	else
 		delete []data.memory;
 

--- a/src/common/nexusdata.cpp
+++ b/src/common/nexusdata.cpp
@@ -48,7 +48,6 @@ NexusData::~NexusData() {
 }
 
 bool NexusData::open(const char *_uri) {
-	file = NexusFile::create();
 	file->setFileName(_uri);
 	if(!file->open(NexusFile::Read))
 		//file = fopen(_uri, "rb+");

--- a/src/common/nexusdata.h
+++ b/src/common/nexusdata.h
@@ -25,7 +25,7 @@ for more details.
 #include "dag.h"
 
 #include <vcg/space/color4.h>
-#include <QFile>
+#include "nexusfile.h"
 
 namespace nx {
 
@@ -111,9 +111,11 @@ public:
 	virtual void loadIndex();
 	virtual void loadIndex(char *buffer);
 
+	virtual void loadImageFromData(TextureData& data, int textureIndex) = 0;
+
 	//FILE *file;
 
-	QFile file;
+	NexusFile* file;
 };
 
 } //namespace

--- a/src/common/nexusfile.h
+++ b/src/common/nexusfile.h
@@ -9,7 +9,6 @@ namespace nx {
 			Append		= 0b00000100,
 			ReadWrite	= Read | Write,
 		};
-		static NexusFile* create();
 		virtual void setFileName(const char* uri) = 0;
 		virtual bool open(OpenMode mode) = 0;
 		virtual int read(char* where, unsigned int length) = 0;

--- a/src/common/nexusfile.h
+++ b/src/common/nexusfile.h
@@ -1,0 +1,22 @@
+#ifndef NX_NEXUSFILE_H
+#define NX_NEXUSFILE_H
+namespace nx {
+	class NexusFile {
+	public:
+		enum OpenMode {
+			Read		= 0b00000001,
+			Write		= 0b00000010,
+			Append		= 0b00000100,
+			ReadWrite	= Read | Write,
+		};
+		static NexusFile* create();
+		virtual void setFileName(const char* uri) = 0;
+		virtual bool open(OpenMode mode) = 0;
+		virtual int read(char* where, unsigned int length) = 0;
+		virtual void* map(unsigned int from, unsigned int size) = 0;
+		virtual bool unmap(void* mapped) = 0;
+		virtual bool seek(unsigned int to) = 0;
+	};
+}
+
+#endif // NX_NEXUSFILE_H

--- a/src/common/qtnexusfile.cpp
+++ b/src/common/qtnexusfile.cpp
@@ -1,0 +1,39 @@
+#include "qtnexusfile.h"
+
+namespace nx {
+	NexusFile* NexusFile::create() { return new QTNexusFile(); }
+	void nx::QTNexusFile::setFileName(const char* uri)
+	{
+		file.setFileName(uri);
+	}
+
+	bool nx::QTNexusFile::open(OpenMode openmode)
+	{
+		QIODevice::OpenMode mode;
+		if (openmode & OpenMode::Read) mode |= QIODevice::ReadOnly;
+		if (openmode & OpenMode::Write) mode |= QIODevice::WriteOnly;
+		if (openmode & OpenMode::Append) mode |= QIODevice::Append;
+
+		return file.open(mode);
+	}
+
+	int nx::QTNexusFile::read(char* where, unsigned int length)
+	{
+		return file.read(where, length);
+	}
+
+	void* nx::QTNexusFile::map(unsigned int from, unsigned int size)
+	{
+		return file.map(from, size);
+	}
+
+	bool nx::QTNexusFile::unmap(void* mapped)
+	{
+		return file.unmap((uchar*)mapped);
+	}
+
+	bool nx::QTNexusFile::seek(unsigned int to)
+	{
+		return file.seek(to);
+	}
+}

--- a/src/common/qtnexusfile.cpp
+++ b/src/common/qtnexusfile.cpp
@@ -1,7 +1,6 @@
 #include "qtnexusfile.h"
 
 namespace nx {
-	NexusFile* NexusFile::create() { return new QTNexusFile(); }
 	void nx::QTNexusFile::setFileName(const char* uri)
 	{
 		file.setFileName(uri);

--- a/src/common/qtnexusfile.h
+++ b/src/common/qtnexusfile.h
@@ -1,0 +1,22 @@
+#ifndef NX_QTNEXUSFILE_H
+#define NX_QTNEXUSFILE_H
+
+#include "nexusfile.h"
+#include <QFile>
+
+namespace nx {
+	class QTNexusFile 
+		: public NexusFile {
+	private:
+		QFile file; 
+	public:
+		void setFileName(const char* uri) override;
+		bool open(OpenMode openmode) override;
+		int read(char* where, unsigned int length) override;
+		void* map(unsigned int from, unsigned int size) override;
+		bool unmap(void* mapped) override;
+		bool seek(unsigned int to) override;
+	};
+}
+
+#endif // NX_QTNEXUSFILE_H

--- a/src/common/traversal.cpp
+++ b/src/common/traversal.cpp
@@ -105,12 +105,12 @@ void Traversal::blockChildren(uint32_t n) {
 	}
 }
 
-bool Traversal::skipNode(quint32 n) {
+bool Traversal::skipNode(uint32_t n) {
 	if(!selected[n]) return true;
 
 	Node &node = nexus->nodes[n];
 
-	for(uint p = node.first_patch; p < node.last_patch(); p++)
+	for(uint32_t p = node.first_patch; p < node.last_patch(); p++)
 		if(!selected[nexus->patches[p].node])
 			return false;
 	return true;

--- a/src/common/traversal.h
+++ b/src/common/traversal.h
@@ -74,7 +74,7 @@ protected:
 	int32_t non_blocked;
 	int32_t prefetch;
 
-	bool skipNode(quint32 node);
+	bool skipNode(uint32_t node);
 
 private:
 	bool add(uint32_t node);                //returns true if added

--- a/src/nxszip/meshdecoder.cpp
+++ b/src/nxszip/meshdecoder.cpp
@@ -71,7 +71,7 @@ void MeshDecoder::decodeFaces() {
 	int start = 0;
 	for(uint32_t p = node.first_patch; p < node.last_patch(); p++) {
 		Patch &patch = patches[p];
-		uint end = patch.triangle_offset;
+		uint32_t end = patch.triangle_offset;
 		decodeFaces(end - start, faces + start*3);
 		start = end;
 	}


### PR DESCRIPTION
This was done by abstracting the functionality needed from QFile into a new abstract class called NexusFile, which each platform has to implement.
A new virtual pure function called NexusData::loadImageFromData that replaces the block of code used to load an image was added, which is implemented in Nexus