### PR TITLE
Removed dependency from QFile in NexusData

### DIFF
--- a/src/common/nexusdata.h
+++ b/src/common/nexusdata.h
@@ -111,7 +111,7 @@ public:
 	virtual void loadIndex();
 	virtual void loadIndex(char *buffer);
 
-	virtual void loadImageFromData(TextureData& data, int textureIndex) = 0;
+	virtual void loadImageFromData(TextureData& data, int textureIndex) { };
 
 	//FILE *file;
 

--- a/src/common/nexusfile.h
+++ b/src/common/nexusfile.h
@@ -12,6 +12,8 @@ namespace nx {
 		virtual void setFileName(const char* uri) = 0;
 		virtual bool open(OpenMode mode) = 0;
 		virtual int read(char* where, unsigned int length) = 0;
+		virtual int write(char* from, unsigned int length) = 0;
+		virtual int size() = 0;
 		virtual void* map(unsigned int from, unsigned int size) = 0;
 		virtual bool unmap(void* mapped) = 0;
 		virtual bool seek(unsigned int to) = 0;

--- a/src/common/qtnexusfile.cpp
+++ b/src/common/qtnexusfile.cpp
@@ -21,6 +21,17 @@ namespace nx {
 		return file.read(where, length);
 	}
 
+
+	int nx::QTNexusFile::write(char* from, unsigned int length)
+	{
+		return file.write(from, length);
+	}
+
+	int QTNexusFile::size()
+	{
+		return file.size();
+	}
+
 	void* nx::QTNexusFile::map(unsigned int from, unsigned int size)
 	{
 		return file.map(from, size);

--- a/src/common/qtnexusfile.h
+++ b/src/common/qtnexusfile.h
@@ -13,6 +13,8 @@ namespace nx {
 		void setFileName(const char* uri) override;
 		bool open(OpenMode openmode) override;
 		int read(char* where, unsigned int length) override;
+		int write(char* from, unsigned int length) override;
+		int size() override;
 		void* map(unsigned int from, unsigned int size) override;
 		bool unmap(void* mapped) override;
 		bool seek(unsigned int to) override;

--- a/src/nxsbuild/CMakeLists.txt
+++ b/src/nxsbuild/CMakeLists.txt
@@ -13,6 +13,8 @@ SET(HEADERS
 	../common/signature.h
 	../common/cone.h
 	../common/virtualarray.h
+    ../common/nexusfile.h
+    ../common/qtnexusfile.h
 	meshstream.h
 	meshloader.h
 	plyloader.h
@@ -34,6 +36,7 @@ SET(SOURCES
 	../../../vcglib/wrap/ply/plylib.cpp
 	../common/virtualarray.cpp
 	../common/cone.cpp
+	../common/qtnexusfile.cpp
 	main.cpp
 	meshstream.cpp
 	meshloader.cpp

--- a/src/nxsedit/CMakeLists.txt
+++ b/src/nxsedit/CMakeLists.txt
@@ -71,6 +71,8 @@ SET(HEADERS
     ../../../vcglib/wrap/system/qgetopt.h
     ../common/virtualarray.h
     ../common/nexusdata.h
+    ../common/nexusfile.h
+    ../common/qtnexusfile.h
     ../common/traversal.h
     ../common/signature.h
     ../nxszip/zpoint.h
@@ -95,6 +97,7 @@ SET(SOURCES
     ../common/nexusdata.cpp
     ../common/traversal.cpp
     ../common/cone.cpp
+	../common/qtnexusfile.cpp
     ../nxszip/meshcoder.cpp
     ../nxszip/meshdecoder.cpp
     ../nxszip/abitstream.cpp

--- a/src/nxsedit/extractor.cpp
+++ b/src/nxsedit/extractor.cpp
@@ -191,7 +191,7 @@ void Extractor::save(QString output, nx::Signature &signature) {
 			
 			quint64 start = in.getBeginOffset();
 			quint64 size = in.getSize();
-			char *memory = (char *)nexus->file.map(start, size);
+			char *memory = (char *)nexus->file->map(start, size);
 			
 			out.offset = file.pos()/NEXUS_PADDING;
 			file.write(memory, size);

--- a/src/nxsedit/main.cpp
+++ b/src/nxsedit/main.cpp
@@ -537,7 +537,7 @@ void checks(NexusData &nexus) {
 			cout << "Node " << i << " of " << n_nodes << " First patch " << node.first_patch << " of " << n_patches << endl;
 			exit(-1);
 		}
-		assert(node.offset * (quint64)NEXUS_PADDING < nexus.file.size());
+		assert(node.offset * (quint64)NEXUS_PADDING < nexus.file->size());
 	}
 	assert(nexus.nodes[n_nodes-1].first_patch = n_patches);
 

--- a/src/nxsedit/main.cpp
+++ b/src/nxsedit/main.cpp
@@ -520,8 +520,8 @@ void recomputeError(NexusData &nexus, QString error_method) {
 
 	nexus.nodes[nexus.header.n_nodes - 1].error = min_error;
 
-	nexus.file.seek(sizeof(Header));
-	nexus.file.write((char *)nexus.nodes, sizeof(nx::Node)* nexus.header.n_nodes);
+	nexus.file->seek(sizeof(Header));
+	nexus.file->write((char *)nexus.nodes, sizeof(nx::Node)* nexus.header.n_nodes);
 	//fseek(nexus.file, sizeof(Header), SEEK_SET);
 	//fwrite(nexus.nodes, sizeof(nx::Node), nexus.header.n_nodes, nexus.file);
 }
@@ -555,13 +555,13 @@ void checks(NexusData &nexus) {
 
 	for(uint i = 0; i < n_textures-1; i++) {
 		Texture &texture = nexus.textures[i];
-		if(texture.offset * (quint64)NEXUS_PADDING >= nexus.file.size()) {
-			cout << "Texture " << i << " offset " << texture.offset*NEXUS_PADDING << " file size " << nexus.file.size() << endl;
+		if(texture.offset * (quint64)NEXUS_PADDING >= nexus.file->size()) {
+			cout << "Texture " << i << " offset " << texture.offset*NEXUS_PADDING << " file size " << nexus.file->size() << endl;
 		}
 	}
-	if(nexus.textures[n_textures-1].offset*NEXUS_PADDING != nexus.file.size()) {
+	if(nexus.textures[n_textures-1].offset*NEXUS_PADDING != nexus.file->size()) {
 		cout << "Last texture " << nexus.textures[n_textures-1].offset*NEXUS_PADDING <<
-				"File size " << nexus.file.size() << endl;
+				"File size " << nexus.file->size() << endl;
 	}
 	return;
 }
@@ -595,8 +595,8 @@ void checkSpheres(NexusData &nexus) {
 	}
 
 	//write back nodes.
-	nexus.file.seek(sizeof(Header));
-	nexus.file.write((char *)nexus.nodes, sizeof(nx::Node)* nexus.header.n_nodes);
+	nexus.file->seek(sizeof(Header));
+	nexus.file->write((char *)nexus.nodes, sizeof(nx::Node)* nexus.header.n_nodes);
 	//fseek(nexus.file, sizeof(Header), SEEK_SET);
 	//fwrite(nexus.nodes, sizeof(Node), n_nodes, nexus.file);
 }

--- a/src/nxsview/CMakeLists.txt
+++ b/src/nxsview/CMakeLists.txt
@@ -28,6 +28,8 @@ SET(HEADERS
 	../common/dag.h
 	../common/controller.h
 	../common/nexusdata.h
+	../common/nexusfile.h
+	../common/qtnexusfile.h
 	../nxszip/bitstream.h
 	../nxszip/tunstall.h
 	../nxszip/meshcoder.h
@@ -50,6 +52,7 @@ SET(SOURCES
 	../common/ram_cache.cpp
 	../common/frustum.cpp
 	../common/nexusdata.cpp
+	../common/qtnexusfile.cpp
 	../nxszip/abitstream.cpp
 	../nxszip/atunstall.cpp
 	../nxszip/meshdecoder.cpp
@@ -71,6 +74,9 @@ find_package(Qt5OpenGL)
 #find_package(glew)
 
 add_executable(nxsview ${SOURCES} ${HEADERS})
-
-target_link_libraries(nxsview corto Qt5::Widgets Qt5::OpenGL GLEW GLU GL curl)
+if (WIN32)
+	target_link_libraries(nxsview corto Qt5::Widgets Qt5::OpenGL GLEW glu32 OpenGL32 curl)
+else()
+	target_link_libraries(nxsview corto Qt5::Widgets Qt5::OpenGL GLEW GLU GL curl)
+endif()
 


### PR DESCRIPTION
This was done by creating an abstract class called NexusFile which abstracts the functionality required from Nexus.  