### PR TITLE
nxsbuild: Fix loading textures for OBJ models

### DIFF
--- a/src/nxsbuild/meshloader.cpp
+++ b/src/nxsbuild/meshloader.cpp
@@ -16,8 +16,20 @@ GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
 for more details.
 */
 #include "meshloader.h"
+#include <QFileInfo>
 
 void MeshLoader::quantize(float &value) {
 	if(!quantization) return;
 	value = quantization*(int)(value/quantization);
+}
+
+void MeshLoader::sanitizeTextureFilepath(QString &textureFilepath) {
+  std::replace( textureFilepath.begin(), textureFilepath.end(), QChar('\\'), QChar('/') );
+}
+
+void MeshLoader::resolveTextureFilepath(const QString &modelFilepath, QString &textureFilepath) {
+  QFileInfo file(modelFilepath);
+  QString path = file.path();
+
+  textureFilepath = path + "/" + textureFilepath;
 }

--- a/src/nxsbuild/meshloader.h
+++ b/src/nxsbuild/meshloader.h
@@ -51,6 +51,8 @@ protected:
 	float quantization;
 
 	void quantize(float &value);
+	void sanitizeTextureFilepath (QString &textureFilepath);
+	void resolveTextureFilepath (const QString &modelFilepath, QString &textureFilepath);
 };
 
 #endif // NX_MESHLOADER_H

--- a/src/nxsbuild/meshstream.cpp
+++ b/src/nxsbuild/meshstream.cpp
@@ -102,8 +102,6 @@ void Stream::load(MeshLoader *loader) {
 
 	if(has_textures) {
 		for(auto tex: loader->texture_filenames) {
-			//windows paths .\ sometimes used in mtl,
-			//std::replace( tex.begin(), tex.end(), QChar('\\'), QChar('/') );
 			textures.push_back(tex);
 		}
 	}
@@ -117,15 +115,6 @@ void Stream::load(QStringList paths, QString material) {
 	foreach(QString file, paths) {
 		qDebug() << "Reading" << qPrintable(file);
 		MeshLoader *loader = getLoader(file, material);
-		if(loader->hasTextures()) {
-			QFileInfo file(paths[0]);
-			QString path = file.path();
-			for(auto &tex: loader->texture_filenames) {
-				//windows paths .\ sometimes used in mtl,
-				std::replace( tex.begin(), tex.end(), QChar('\\'), QChar('/') );
-				tex = path + "/" + tex;
-			}
-		}
 		load(loader);
 		//box.Add(loader->box); //this lineB AFTER the mesh is streamed
 		delete loader;

--- a/src/nxsbuild/objloader.cpp
+++ b/src/nxsbuild/objloader.cpp
@@ -39,6 +39,8 @@ ObjLoader::ObjLoader(QString filename, QString _mtl):
 	file.setFileName(filename);
 	if(!file.open(QFile::ReadOnly))
 		throw QString("could not open file %1. Error: %2").arg(filename).arg(file.errorString());
+
+	readMTL();	
 }
 
 ObjLoader::~ObjLoader() {
@@ -189,6 +191,9 @@ void ObjLoader::readMTL() {
 			qint32 color = R + G + B + A;
 			colors_map.insert(mtltag, color);
 
+			sanitizeTextureFilepath(txtfname);
+			resolveTextureFilepath(file.fileName(), txtfname);
+
 			if (txtfname.length() > 0) {
 				textures_map.insert(mtltag, txtfname);
 				bool exists = false;
@@ -207,6 +212,8 @@ void ObjLoader::readMTL() {
 	std::cout << "Colors read: " << cnt << std::endl;
 	for (auto fn : texture_filenames)
 		std::cout << qPrintable("Texture: " + fn) << std::endl;
+	if (texture_filenames.size() > 0)
+		has_textures = true;
 	if (cnt)
 		has_colors = true;
 }
@@ -285,11 +292,7 @@ quint32 ObjLoader::getTriangles(quint32 size, Triangle *faces) {
 	if (n_triangles == 0) {
 		cacheVertices();
 		cacheTextureUV();
-		readMTL();
 	}
-
-	if (texture_filenames.size() > 0)
-		has_textures = true;
 
 	char buffer[1024];
 	file.seek(current_tri_pos);

--- a/src/nxsbuild/plyloader.cpp
+++ b/src/nxsbuild/plyloader.cpp
@@ -133,6 +133,11 @@ PlyLoader::PlyLoader(QString filename):
 	}
 //	if(has_textures && texture_filenames.size() == 0)
 //		has_textures = false;
+
+	for(auto &tex: texture_filenames) {
+		sanitizeTextureFilepath(tex);
+		resolveTextureFilepath(filename, tex);
+	}
 }
 
 PlyLoader::~PlyLoader() {


### PR DESCRIPTION
Fixes: #120

**Description**

Textures referenced in MTL files of OBJ models are now loaded correctly by *nxsbuild*. The fix involves reading the material file and initializing the ```has_textures``` flag earlier in the workflow (inside the constructor of the ```ObjLoader```), and texture filepaths are being adjusted appropriately before they're attempted to be loaded. This adjustment is now done using separate functions (```sanitizeTextureFilepath```, ```resolveTextureFilepath```) which were added to the ```MeshLoader``` class. Each loader which supports textures (currently ```ObjLoader``` and ```PlyLoader```) calls these functions as a part of its worfklow.

**Long story what problem this PR fixes**

```Stream::load(QStringList paths, QString material)``` cannot correctly adjust texture paths (i.e. sanitization and prepending the directory where OBJ is located before their filename) for OBJ models because the instantiated ```ObjLoader``` parses the accompanying MTL file (where information about textures is) much later. At the time when the foreach loop of the ```Stream::load``` function is executed, the ```loader``` thinks that the OBJ has no textures (since instances of ```ObjLoader``` are initialized with ```has_textures``` set to ```false```). The ```if(loader->hasTextures())``` condition always evaluates to false, and texture filepaths are not adjusted. And even if the condition would evaluate to true, it wouldn't help either because the ```ObjLoader``` haven't parsed the MTL file yet and it simply doesn't know about any textures.

It seems that the bug was introduced in the commit [a3759ef](https://github.com/cnr-isti-vclab/nexus/commit/a3759ef815e1f8f4cfaf0dea46d665bbe2aa6ccc) by splitting the logic from ```Stream::load(QStringList paths, QString material)``` into two overloaded functions. Prior to the split, everything worked fine because ```Stream::loadMesh``` was called directly after obtaining ```ObjLoader``` and just before the if condition that checks for textures presence. This means that when the code got to that if condition, the MTL file has already been parsed (actually the entire OBJ model as well), the condition evaluated to true, and texture paths were adjusted properly.

The PR fixes the bug in the following way:
- the call for reading MTL file (```readMTL()```) is moved from inside the ```ObjLoader::getTriangles()``` to the ```ObjLoader``` constructor
- the initialization of ```has_textures``` is moved from ```ObjLoader::getTriangles()``` to the ```ObjLoader::readMTL()```
- adjustment of texture paths is done by calling two new separate functions (```MeshLoader::sanitizeTextureFilepath```, ```MeshLoader::resolveTextureFilepath```)
  - this is because each loader needs to adjust texture paths at different points in their workflow
    - ```ObjLoader``` needs to adjust texture paths inside the ```readMTL()``` (before inserting each texture filepath into its ```textures_map```)
    - ```PlyLoader``` can adjust texture path at the end of its constructor