### PR TITLE
nexus js - three.js: Fix raycasting to always return the closest intersection point

### DIFF
--- a/html/js/nexus_three.js
+++ b/html/js/nexus_three.js
@@ -280,7 +280,7 @@ NexusObject.prototype.raycast = function(raycaster, intersects) {
 			if(d < raycaster.near || d > raycaster.far ) continue;
 			if(distance == -1.0 || d < distance) {
 				distance = d;
-				intersect = hit;
+				intersect = hit.clone();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: #123

**Description**

This PR fixes raycasting of a Nexus mesh to always return the closest intersection point found on the casted ray. The fix involves cloning found intersection points before remembering them.

**Long story what problem this PR fixes**

The problem is that the [original raycasting procedure **assigns**](https://github.com/cnr-isti-vclab/nexus/blob/9f56edab7cf80d2d4a654e65be087ebd973f66bd/html/js/nexus_three.js#L283) a newly found closest interection point (```hit```) to the ```intersect``` variable - see an excerpt of the whole procedure below:

```js
// nexus_three.js, around line 231

NexusObject.prototype.raycast = function(raycaster, intersects) {
  // (...)
  
  var point = new THREE.Vector3(0, 0, 0);
  var distance = -1.0;
  var intersect = raycaster.ray.intersectSphere( sphere, point );

  // (...)

  if(!nexus.sink || !nexus.basei) {
    // (...)
  } else {
    // (...)

    for(var j = 0; j < nexus.basei.length; j += 3) {
      // (...)

      var hit = ray.intersectTriangle( C, B, A, false, point );
      // (...)

      if(d < raycaster.near || d > raycaster.far ) continue;
      if(distance == -1.0 || d < distance) {
        distance = d;
        intersect = hit; // ❗ THE PROBLEM
      }
    }
  }

  if(distance == -1.0) return;
  intersects.push({ distance: distance, point: intersect, object: this} );
  return;
}
```

However, using a plain assignment isn't correct in this case, because the ```intersect``` variable ends up **referencing** the object referenced by the ```hit``` variable, which in turn references the object referenced by the ```point``` variable. This is caused by the slightly tricky fact that the three.js' [intersectTriangle](https://threejs.org/docs/index.html?q=ray#api/en/math/Ray.intersectTriangle) function's signature is ```(a, b, c, backfaceCulling, target)``` and that it doesn't return a new object - it always returns the passed ```target``` object (or ```null``` in case of no intersection), which is ```point``` in our case. 

Each time the ```intersectTriangle``` is executed and finds a new intersection, it stores it in the ```point```. So if the last found intersection isn't actually the closest one, then we don't get the closest point returned from the whole raycasting procedure (since the actual closest point was overwritten and thus lost).

The PR fixes the bug in the following way:
- the newly found intersection point (```hit```) is cloned, and the clone is assigned to the variable holding the closest intersection (```intersect```)