### PR TITLE
nexus js: Fix displaying of textured models

### DIFF
--- a/html/js/nexus.js
+++ b/html/js/nexus.js
@@ -1120,8 +1120,8 @@ function requestNodeTexture(context, node) {
 	} else {
 		Object.assign(request, {
 			url:m.url,
-			start:m.noffsets[n],
-			end:m.noffsets[n+1],
+			start:m.textures[tex],
+			end:m.textures[tex+1],
 		});
 	}
 	m.texreq[n] = m.httpRequest(request);


### PR DESCRIPTION
Fixes: #125

**Description**

This PR fixes displaying of textured models by using correct variables during the initialization of the texture request parameters.

**Long story what problem this PR fixes**

The [requestNodeTexture](https://github.com/cnr-isti-vclab/nexus/blob/9f56edab7cf80d2d4a654e65be087ebd973f66bd/html/js/nexus.js#L1088) initializes texture requests in the following way:

```js
// nexus.js, around line 1088

function requestNodeTexture(context, node) {
  // (...)

  var n = node.id;
  var m = node.mesh;

  if(!m.vertex.texCoord) return;

  var tex = m.patches[m.nfirstpatch[n]*3+2];

  // (...)

  if(m.deepzoom) {
		request.url = m.baseurl + tex + '.jpg';
	} else {
		Object.assign(request, {
			url:m.url,
			start:m.noffsets[n], // ❗ THE PROBLEM
			end:m.noffsets[n+1], // ❗ THE PROBLEM
		});
	}

  // (...)
}
```

This way of initialization isn't correct, because ```m.noffsets``` and ```n``` are related to nodes, not textures. It seems that the bug was introduced in the commit [5f96f56](https://github.com/cnr-isti-vclab/nexus/commit/5f96f56dd8f9ef1744df8963d37ef1c7f52fdb2f).

The PR fixes the bug in the following way:
- use ```m.textures``` and ```tex``` during the initialization of the request instead of ```m.noffsets``` and ```n```