### PR TITLE
nexus js - three.js: Correct bounding sphere test for raycasting

### DIFF
--- a/html/js/nexus_three.js
+++ b/html/js/nexus_three.js
@@ -238,8 +238,8 @@ NexusObject.prototype.raycast = function(raycaster, intersects) {
 	var r = nexus.sphere.radius;
 	var center = new THREE.Vector3(c[0], c[1], c[2]);
 	var sphere = new THREE.Sphere(center, r);
-	var m = new THREE.Matrix4();
-	m.getInverse(this.matrixWorld);
+	sphere.applyMatrix4(this.matrixWorld);
+	var m = new THREE.Matrix4().copy(this.matrixWorld).invert();
 	var ray = new THREE.Ray();
 	ray.copy(raycaster.ray).applyMatrix4(m);
 

--- a/html/js/nexus_three.js
+++ b/html/js/nexus_three.js
@@ -280,7 +280,7 @@ NexusObject.prototype.raycast = function(raycaster, intersects) {
 			if(d < raycaster.near || d > raycaster.far ) continue;
 			if(distance == -1.0 || d < distance) {
 				distance = d;
-				intersect = hit;
+				intersect = hit.clone();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: #129
Depends on: #124

**Description**

Before the raycasting is performed, the bounding sphere of a Nexus mesh is transformed by the mesh's world matrix. This makes the bounding sphere test used for early exit from the raycasting to work properly.

**Long story what problem this PR fixes**

The [raycasting procedure](https://github.com/cnr-isti-vclab/nexus/blob/9f56edab7cf80d2d4a654e65be087ebd973f66bd/html/js/nexus_three.js#L231) employs a bounding sphere test before it actually tries to raycast the Nexus mesh - if the ray doesn't hit the bounding sphere of the mesh, the raycasting can exit early and instantly report no intersections. See an excerpt of the procedure below:

```js
// nexus_three.js, around line 231

NexusObject.prototype.raycast = function(raycaster, intersects) {
  // (...)
  
  var c = nexus.sphere.center;
  var r = nexus.sphere.radius;
  var center = new THREE.Vector3(c[0], c[1], c[2]);
  // ❗ PROBLEM: This bounding sphere is valid only for the original, untransformed Nexus mesh.
  var sphere = new THREE.Sphere(center, r);
  var m = new THREE.Matrix4();
  m.getInverse(this.matrixWorld);
  var ray = new THREE.Ray();
  ray.copy(raycaster.ray).applyMatrix4(m);

  var point = new THREE.Vector3(0, 0, 0);
  var distance = -1.0;
  var intersect = raycaster.ray.intersectSphere( sphere, point );
  if(!intersect)
    return;

  // (...)
}
```

However, the ray is casted against the bounding sphere of the original Nexus mesh and that is incorrect - the Nexus mesh has actually been [transformed during the scene initialization](https://github.com/cnr-isti-vclab/nexus/blob/9f56edab7cf80d2d4a654e65be087ebd973f66bd/html/raycast.html#L78) (in order to fit into the view), so it's necessary to transform the bounding sphere as well.

The PR fixes the bug in the following way:
- before the bounding sphere is used for the test, it's transformed by the Nexus mesh's world matrix

The PR also updates the code for obtaining inverse of the world matrix (to get rid of the three.js warning ```"THREE.Matrix4: .getInverse() has been removed. Use matrixInv.copy( matrix ).invert(); instead."```).