### PR TITLE
fix(nxsbuild): loading materials without textures for OBJ models

### DIFF
--- a/src/nxsbuild/objloader.cpp
+++ b/src/nxsbuild/objloader.cpp
@@ -191,10 +191,10 @@ void ObjLoader::readMTL() {
 			qint32 color = R + G + B + A;
 			colors_map.insert(mtltag, color);
 
-			sanitizeTextureFilepath(txtfname);
-			resolveTextureFilepath(file.fileName(), txtfname);
-
 			if (txtfname.length() > 0) {
+				sanitizeTextureFilepath(txtfname);
+				resolveTextureFilepath(file.fileName(), txtfname);
+				
 				textures_map.insert(mtltag, txtfname);
 				bool exists = false;
 				for (auto fn : texture_filenames)


### PR DESCRIPTION
**Description**

The pull request #120 (merged into master as e082f603dae1dc9485b3e11fc893dfed6383bdba) introduced a bug which caused nxsbuild to crash when there are materials in the MTL file without textures. It was because the code attempted to sanitize the texture filename even if no texture filename was available, and this made nxsbuild to look for a texture that couldn't possibly exist. This PR fixes the bug by performing texture filename sanitization only if the material actually has some texture.