### PR TITLE
Update default diffuse color used when reading mtl files

### DIFF
--- a/src/nxsbuild/objloader.cpp
+++ b/src/nxsbuild/objloader.cpp
@@ -131,9 +131,9 @@ void ObjLoader::readMTL() {
 		if (str.startsWith("newmtl", Qt::CaseInsensitive)){
 			QString mtltag = str.section(" ", 1);
 			QString txtfname;
-			qint32 R = 0;
-			qint32 G = 0;
-			qint32 B = 0;
+			qint32 R = 0xff000000;
+			qint32 G = 0x00ff0000;
+			qint32 B = 0x0000ff00;
 			qint32 A = 255;
 
 			do {


### PR DESCRIPTION
Currently, if an OBJ file uses an MTL file which does not include a Kd value, the OBJ file will be black when displayed. I think we could update the default RGB color used when processing the MTL file since the default value will be updated anyway if a Kd value is present.

An example mesh can be downloaded from the following link: https://cloud.pix4d.com/dataset/911895/map?shareToken=5e81e91f-8a73-4201-81f4-748056fa0370. This mesh has texture but there is no Kd value in the MTL file and because of that it will be black when displayed. With this change the texture will be displayed correctly.
